### PR TITLE
[FIX] do not arbitrarily filter on company in queries

### DIFF
--- a/mis_builder/models/mis_builder.py
+++ b/mis_builder/models/mis_builder.py
@@ -458,11 +458,6 @@ class MisReportInstancePeriod(models.Model):
                     self.date_to, self._context.get('tz', 'UTC'), add_day=1)
                 domain.extend([(query.date_field.name, '>=', datetime_from),
                                (query.date_field.name, '<', datetime_to)])
-            # TODO: we probably don't need company_id here
-            if model._columns.get('company_id'):
-                domain.extend(['|', ('company_id', '=', False),
-                               ('company_id', '=',
-                                self.report_instance_id.company_id.id)])
             field_names = [f.name for f in query.field_ids]
             if not query.aggregate:
                 data = model.search_read(domain, field_names)


### PR DESCRIPTION
Such a filter is too restrictive and may override record rules.

If required, it should be made explicit in each query domain., possibly by giving access to a context variable containing the report instance company_id.

@laetitia-gangloff @adrienpeiffer what do you think?
