### PR TITLE
[FIX] remove field 'landscape_pdf' and reorganize views 

### DIFF
--- a/mis_builder/models/mis_builder.py
+++ b/mis_builder/models/mis_builder.py
@@ -746,8 +746,7 @@ class MisReportInstance(orm.Model):
         'root_account': fields.many2one('account.account',
                                         domain='[("parent_id", "=", False)]',
                                         string="Account chart",
-                                        required=True),
-        'landscape_pdf': fields.boolean(string='Landscape PDF')
+                                        required=True)
     }
 
     _defaults = {

--- a/mis_builder/views/mis_builder.xml
+++ b/mis_builder/views/mis_builder.xml
@@ -147,15 +147,14 @@
                         <button type="action" name="%(xls_export)d" string="Export" icon="gtk-execute" />
                         <button type="action" name="%(mis_report_instance_add_to_dashboard_action)d" string="Add to dashboard" icon="gtk-add" />
                     </div>
-                    <group col="4">
-                        <field name="report_id" colspan="4"/>
+                    <group>
+                        <field name="report_id"/>
                         <field name="description"/>
-                        <field name="landscape_pdf" />
                         <field name="root_account"/>
                         <field name="company_id" groups="base.group_multi_company"/>
                         <field name="date"/>
                         <field name="target_move"/>
-                        <field name="period_ids" colspan="4">
+                        <field name="period_ids">
                             <tree string="KPI's" editable="bottom" colors="red:valid==False">
                                 <field name="sequence" widget="handle"/>
                                 <field name="name"/>


### PR DESCRIPTION
The field 'landscape_pdf' is not used in 7.0. Removing this column caused issues in the visualization of the MIS Report form view, so also adjusted it.
