### PR TITLE
[IMP] ability to insert prefixes

### DIFF
--- a/mis_builder/models/mis_builder.py
+++ b/mis_builder/models/mis_builder.py
@@ -76,7 +76,7 @@ class MisReportKpi(models.Model):
     In addition to a name and description, it has an expression
     to compute it based on queries defined in the MIS report.
     It also has various informations defining how to render it
-    (numeric or percentage or a string, a suffix, divider) and
+    (numeric or percentage or a string, a prefix, a suffix, divider) and
     how to render comparison of two values of the KPI.
     KPI's have a sequence and are ordered inside the MIS report.
     """
@@ -107,6 +107,7 @@ class MisReportKpi(models.Model):
                                default='1')
     dp = fields.Integer(string='Rounding', default=0)
     suffix = fields.Char(size=16, string='Suffix')
+    prefix = fields.Char(size=16, string='Prefix')
     compare_method = fields.Selection([('diff', _('Difference')),
                                        ('pct', _('Percentage')),
                                        ('none', _('None'))],
@@ -163,10 +164,10 @@ class MisReportKpi(models.Model):
             return '#N/A'
         elif self.type == 'num':
             return self._render_num(lang_id, value, self.divider,
-                                    self.dp, self.suffix)
+                                    self.dp, self.prefix, self.suffix)
         elif self.type == 'pct':
             return self._render_num(lang_id, value, 0.01,
-                                    self.dp, '%')
+                                    self.dp, '', '%',)
         else:
             return unicode(value)
 
@@ -180,7 +181,7 @@ class MisReportKpi(models.Model):
             return self._render_num(
                 lang_id,
                 value - base_value,
-                0.01, self.dp, _('pp'), sign='+')
+                0.01, self.dp, '', _('pp'), sign='+')
         elif self.type == 'num':
             if average_value:
                 value = value / float(average_value)
@@ -190,17 +191,17 @@ class MisReportKpi(models.Model):
                 return self._render_num(
                     lang_id,
                     value - base_value,
-                    self.divider, self.dp, self.suffix, sign='+')
+                    self.divider, self.dp, self.prefix, self.suffix, sign='+')
             elif self.compare_method == 'pct':
                 if round(base_value, self.dp) != 0:
                     return self._render_num(
                         lang_id,
                         (value - base_value) / abs(base_value),
-                        0.01, self.dp, '%', sign='+')
+                        0.01, self.dp, '', '%', sign='+')
         return ''
 
     def _render_num(self, lang_id, value, divider,
-                    dp, suffix, sign='-'):
+                    dp, prefix, suffix, sign='-'):
         divider_label = _get_selection_label(
             self._columns['divider'].selection, divider)
         if divider_label == '1':
@@ -211,8 +212,11 @@ class MisReportKpi(models.Model):
             '%%%s.%df' % (sign, dp),
             value,
             grouping=True)
-        value = u'%s\N{NO-BREAK SPACE}%s%s' % \
-            (value, divider_label, suffix or '')
+        space = ''
+        if value:
+            space = u'\N{NO-BREAK SPACE}'
+        value = u'%s%s%s%s%s' % \
+            (prefix or '', value, space, divider_label, suffix or '')
         value = value.replace('-', u'\N{NON-BREAKING HYPHEN}')
         return value
 
@@ -536,6 +540,7 @@ class MisReportInstancePeriod(models.Model):
                     'val_r': kpi_val_rendered,
                     'val_c': kpi_val_comment,
                     'style': kpi_style,
+                    'prefix': kpi.prefix,
                     'suffix': kpi.suffix,
                     'dp': kpi.dp,
                     'is_percentage': kpi.type == 'pct',

--- a/mis_builder/models/mis_builder.py
+++ b/mis_builder/models/mis_builder.py
@@ -212,11 +212,15 @@ class MisReportKpi(models.Model):
             '%%%s.%df' % (sign, dp),
             value,
             grouping=True)
-        space = ''
-        if value:
-            space = u'\N{NO-BREAK SPACE}'
-        value = u'%s%s%s%s%s' % \
-            (prefix or '', value, space, divider_label, suffix or '')
+
+        if prefix:
+            if '-' in value:
+                value = value.replace('-', '-%s' % (prefix,))
+            else:
+                value = prefix + value
+
+        value = u'%s%s%s' % \
+            (value, divider_label, suffix or '')
         value = value.replace('-', u'\N{NON-BREAKING HYPHEN}')
         return value
 

--- a/mis_builder/report/mis_builder_xls.py
+++ b/mis_builder/report/mis_builder_xls.py
@@ -118,8 +118,10 @@ class mis_builder_xls(report_xls):
                 if value.get('dp'):
                     num_format_str += '.'
                     num_format_str += '0' * int(value['dp'])
+                if value.get('prefix'):
+                    num_format_str = '"%s"' % value['prefix'] + num_format_str
                 if value.get('suffix'):
-                    num_format_str = num_format_str + ' "%s"' % value['suffix']
+                    num_format_str += ' "%s"' % value['suffix']
                 kpi_cell_style = xlwt.easyxf(
                     _xs['borders_all'] + _xs['right'],
                     num_format_str=num_format_str)

--- a/mis_builder/tests/test_mis_builder.py
+++ b/mis_builder/tests/test_mis_builder.py
@@ -65,6 +65,7 @@ class test_mis_builder(common.TransactionCase):
                                                   'mis_report_instance_'
                                                   'period_test'),
                             'style': None,
+                            'prefix': False,
                             'suffix': False,
                             'expr': 'len(test)',
                             'val_c': 'total_test = len(test)',

--- a/mis_builder/views/mis_builder.xml
+++ b/mis_builder/views/mis_builder.xml
@@ -49,6 +49,7 @@
                                 <field name="type"/>
                                 <field name="dp" attrs="{'invisible': [('type', '=', 'str')]}"/>
                                 <field name="divider" attrs="{'invisible': [('type', '=', 'str')]}"/>
+                                <field name="prefix"/>
                                 <field name="suffix"/>
                                 <field name="compare_method" attrs="{'invisible': [('type', '=', 'str')]}"/>
                                 <field name="default_css_style"/>


### PR DESCRIPTION
This PR adds a new field to the MIS Report template, to the KPI section, called 'suffix'.

The typical use case will be for companies that operate in currencies such as $, where the sign is indicated as a prefix of the value. Note that with negative numbers the prefix goes as -$100, not as $-100.

![image](https://cloud.githubusercontent.com/assets/7683926/11714535/33cad2ea-9f3b-11e5-82f3-39f5c3dbd0e5.png)

![image](https://cloud.githubusercontent.com/assets/7683926/11715186/338691f2-9f40-11e5-93b8-8159ae6e9dc3.png)

![image](https://cloud.githubusercontent.com/assets/7683926/11715209/4b221f98-9f40-11e5-8061-3ce2d372b572.png)
